### PR TITLE
[google_workspace] Allow to set credentials directly in the config. (…

### DIFF
--- a/packages/google_workspace/changelog.yml
+++ b/packages/google_workspace/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.5.0"
+  changes:
+    - description: Allow to set credentials directly in the config.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/3430
 - version: "1.4.0"
   changes:
     - description: Update to ECS 8.2

--- a/packages/google_workspace/data_stream/admin/_dev/test/system/test-default-config.yml
+++ b/packages/google_workspace/data_stream/admin/_dev/test/system/test-default-config.yml
@@ -2,7 +2,19 @@ input: httpjson
 service: google_workspace
 vars:
   preserve_original_event: true
-  jwt_file: "{{SERVICE_LOGS_DIR}}/credentials.json"
+  jwt_json: |
+    {
+      "type": "service_account",
+      "project_id": "system-tests",
+      "private_key_id": "a2ef9c637b4176ec994606cb08724a1b79bc0666",
+      "private_key": "-----BEGIN PRIVATE KEY-----\nMIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQC9SzdiBfhGcQrN\nLKofn3198cwOJ3DclRM3On9qVEHKIY3aCcLZgst4HyBtkefZeSVgIRPWhStWY8CK\nPBXZHM9jAifSQiHjNU4o7v5EMIKuCrwKAgbXFnJSEwXe7CfzrytKZfkVndPf+ZrH\nnUSwAmbNrB5/VOqtBF0QrG48FCz/ipZph5AJ5h5kFVyDZvwJSaDfDWUHTvZfO3tw\nlSnwVTWztT0d+CDYOyWH34NJVfTKirA3xifDgVcxLKoC7850FsZqJ05HpiOUrHc5\nJRRiy4HurdcPKKBvpVrtbvftBMsiG0RvnqXgTSI7iMNPjUtpjLC9GlZ6B+8egUEd\ndtdPoDG1AgMBAAECggEAP2ks+ldJnj9MAQNPUhyZa1FOrAcmVZ5Su5OLD1F+YHnx\nDPNsJHUeN/UlZc8UvdNJY/RwstIVfHEaFLSgFQUDrAUS1ep1c6ltr2SwJKOjgy3x\nY+Dd7buFPF1HADBYCdfKRrf2QvmF+mehI/FZCyUizw8zgDAwFRl7G5THsLSJhmiQ\nwDc9WbPFLyswtmeKoAqMiHHqV63PtJunqvGbrDTHh9f4P5JVtreMoPWzE9czQ2ZI\n5nBHOFP/EA6twyRalqOsm3XoFmyrWMmJtm/JJsDlGr/LZcVbtghxybEYo8p/VLpo\nJmBSJgM17rwGhniDWXWXXOfx2fkNZEhVIeGvZYJRgQKBgQDOHnepihIu650pTfRD\nfcUyPN9oYLzI2mwv70H3FzJQftt3pqmWhlX2adaXYJ65/8xwr6SmkHmYjTvfuCoT\nSFApzv9fnYcD6vCsk5AhLpbarWR3MEU1SCvaiFuRNrdTcR8MGSglWPLLVXCI6f/g\nF9kZ/Ngz7MkvD2bNT/WjNj3LMQKBgQDrGmPo0gvfk+QoFtL05+dDDrB2IxUokdqa\nRzdecC8wV01l8lIj4TDqo7W1wwxdEUvCbUYriE2BoXi1v3jF+wfluqJOL30Ex5kb\nUO5At+DWakxzgy3v0F32AOZRISAGMdbrNFaLpjD9t9NGbL8kiestfs2QuTISHJwU\nfD47jFDlxQKBgHrczGVh6O7RAVByqCxm1tnYUS8torpzAFQeYQrBZ/t1cqrCzInu\nL2V/tytqq5KheKKfAB1NNz4IyezUITh3PVl+itja1HUwYR/todc1pzRYcO9e9ZIK\nICHWcAaCQArb/i6+/CAvAiLUHg1utlhEvuNvxQxGk7Gak6PEit4r4e+xAoGBAIOR\nrT/p7IMefJyCyWQNM7qvScmTMJAXr8KPAEl1drMS6FmZFqbFq15kZ5hko1KiD0er\nZ42NJfLZrnfnw2roZS8HFzWyFcDLAr/qtqq5PLZBnq82RkrizPKS5lGYvBc7ZQ8T\npytXwir66N2MlhuYo2g+gkPvoDnKkP5V2W3xxIQRAoGBAIDayGKqE1iZwF72R0xQ\nVg8y2x9JoxY1lDGA8oLzYKcp7OslI6sPhv/NGnkQBwV964dcffnn6dezFyKKBGir\nDSiM9duWTttlzzUhUQMHCua2z/LXjz1XMb0LoSEOVdk00TDgRMSFhBLhr3ZXmoLb\nIqi7is4z2mP8pbcIIlmloogE\n-----END PRIVATE KEY-----",
+      "client_email": "foo@bar.com",
+      "client_id": "007155790781103885639",
+      "auth_uri": "http://google_workspace:8080/o/oauth2/auth",
+      "token_uri": "http://google_workspace:8080/token",
+      "auth_provider_x509_cert_url": "http://google_workspace:8080/oauth2/v1/certs",
+      "client_x509_cert_url": "http://google_workspace:8080/robot/v1/metadata/x509/foo%40bar.com"
+    }
   delegated_account: test@example.com
   api_host: http://{{Hostname}}:{{Port}}
 data_stream:

--- a/packages/google_workspace/data_stream/admin/agent/stream/httpjson.yml.hbs
+++ b/packages/google_workspace/data_stream/admin/agent/stream/httpjson.yml.hbs
@@ -2,6 +2,7 @@ config_version: "2"
 interval: {{interval}}
 auth.oauth2.provider: google
 auth.oauth2.google.jwt_file: {{jwt_file}}
+auth.oauth2.google.jwt_json: {{jwt_json}}
 auth.oauth2.google.delegated_account: {{delegated_account}}
 auth.oauth2.scopes:
   - https://www.googleapis.com/auth/admin.reports.audit.readonly

--- a/packages/google_workspace/data_stream/drive/agent/stream/httpjson.yml.hbs
+++ b/packages/google_workspace/data_stream/drive/agent/stream/httpjson.yml.hbs
@@ -2,6 +2,7 @@ config_version: "2"
 interval: {{interval}}
 auth.oauth2.provider: google
 auth.oauth2.google.jwt_file: {{jwt_file}}
+auth.oauth2.google.jwt_json: {{jwt_json}}
 auth.oauth2.google.delegated_account: {{delegated_account}}
 auth.oauth2.scopes:
   - https://www.googleapis.com/auth/admin.reports.audit.readonly

--- a/packages/google_workspace/data_stream/groups/agent/stream/httpjson.yml.hbs
+++ b/packages/google_workspace/data_stream/groups/agent/stream/httpjson.yml.hbs
@@ -2,6 +2,7 @@ config_version: "2"
 interval: {{interval}}
 auth.oauth2.provider: google
 auth.oauth2.google.jwt_file: {{jwt_file}}
+auth.oauth2.google.jwt_json: {{jwt_json}}
 auth.oauth2.google.delegated_account: {{delegated_account}}
 auth.oauth2.scopes:
   - https://www.googleapis.com/auth/admin.reports.audit.readonly

--- a/packages/google_workspace/data_stream/login/agent/stream/httpjson.yml.hbs
+++ b/packages/google_workspace/data_stream/login/agent/stream/httpjson.yml.hbs
@@ -2,6 +2,7 @@ config_version: "2"
 interval: {{interval}}
 auth.oauth2.provider: google
 auth.oauth2.google.jwt_file: {{jwt_file}}
+auth.oauth2.google.jwt_json: {{jwt_json}}
 auth.oauth2.google.delegated_account: {{delegated_account}}
 auth.oauth2.scopes:
   - https://www.googleapis.com/auth/admin.reports.audit.readonly

--- a/packages/google_workspace/data_stream/saml/agent/stream/httpjson.yml.hbs
+++ b/packages/google_workspace/data_stream/saml/agent/stream/httpjson.yml.hbs
@@ -2,6 +2,7 @@ config_version: "2"
 interval: {{interval}}
 auth.oauth2.provider: google
 auth.oauth2.google.jwt_file: {{jwt_file}}
+auth.oauth2.google.jwt_json: {{jwt_json}}
 auth.oauth2.google.delegated_account: {{delegated_account}}
 auth.oauth2.scopes:
   - https://www.googleapis.com/auth/admin.reports.audit.readonly

--- a/packages/google_workspace/data_stream/user_accounts/agent/stream/httpjson.yml.hbs
+++ b/packages/google_workspace/data_stream/user_accounts/agent/stream/httpjson.yml.hbs
@@ -2,6 +2,7 @@ config_version: "2"
 interval: {{interval}}
 auth.oauth2.provider: google
 auth.oauth2.google.jwt_file: {{jwt_file}}
+auth.oauth2.google.jwt_json: {{jwt_json}}
 auth.oauth2.google.delegated_account: {{delegated_account}}
 auth.oauth2.scopes:
   - https://www.googleapis.com/auth/admin.reports.audit.readonly

--- a/packages/google_workspace/manifest.yml
+++ b/packages/google_workspace/manifest.yml
@@ -1,6 +1,6 @@
 name: google_workspace
 title: Google Workspace Audit Reports
-version: 1.4.0
+version: 1.5.0
 release: ga
 description: Collect audit reports from Google Workspaces with Elastic Agent.
 type: integration
@@ -14,7 +14,7 @@ icons:
 categories:
   - security
 conditions:
-  kibana.version: ^7.16.0 || ^8.0.0
+  kibana.version: ^8.4.0
 policy_templates:
   - name: google_workspace
     title: Google Workspace logs
@@ -27,7 +27,16 @@ policy_templates:
             title: Jwt File
             description: Specifies the path to the JWT credentials file.
             multi: false
-            required: true
+            required: false
+            show_user: true
+          - name: jwt_json
+            type: text
+            title: Jwt JSON
+            description: |
+              Raw contents of the JWT file. Useful when hosting
+              a file along with the agent is not possible.
+            multi: false
+            required: false
             show_user: true
           - name: delegated_account
             type: text


### PR DESCRIPTION
…#3430)

* Allow to set credentials directly in the config.

* Set PR number in changelog

* Add key for tests

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
-

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
